### PR TITLE
Update accessibility note for Octicons

### DIFF
--- a/contributing/content-markup-reference.md
+++ b/contributing/content-markup-reference.md
@@ -85,14 +85,14 @@ You can also add a header that includes the name of the language and a button to
 
 ## Octicons
 
-Octicons are icons used across GitHub’s interface. We reference Octicons when documenting the user interface. Find the name of the Octicon on the [Octicons site](https://primer.style/octicons). For accessibility purposes, use [the `aria-label` option](https://primer.style/octicons/packages/javascript#aria-label) to describe the Octicon.
+Octicons are icons used across GitHub’s interface. We reference Octicons when documenting the user interface. Find the name of the Octicon on the [Octicons site](https://primer.style/octicons). For accessibility purposes, use [the `aria-label` option](https://primer.style/octicons/packages/javascript#aria-label) to describe the Octicon. The `aria-label` should describe the meaning of the symbol, not its visual characteristics - for example "Required", not "Check mark".
 
 ### Usage
 
 ```
 {% octicon "<name of octicon>" %}
 {% octicon "plus" %}
-{% octicon "plus" aria-label="The plus icon" %}
+{% octicon "plus" aria-label="Add file" %}
 ```
 
 ## Operating system tags


### PR DESCRIPTION
Обновленное руководство для Octicons, чтобы посоветовать использовать арию-метку, которая описывает значение октикона, а не визуальные характеристики

<! -
Спасибо за участие в этом проекте! Вы должны заполнить информацию ниже, прежде чем мы сможем просмотреть этот запрос. Объясняя, почему вы вносите изменения ( или ссылаетесь на проблему ) и какие изменения вы внесли, мы можем перенастроить ваш запрос на извлечение в лучшую команду для рассмотрения.
- >

### Почему:

Закрывает вопрос

<! - Если есть проблема для вашего изменения, пожалуйста, замените ISSUE выше ссылкой на проблему.
Если существует _not_ существующая проблема, сначала откройте ее, чтобы повысить вероятность принятия этого обновления: https://github.com/github/docs/issues/new/choose. - >

### Что изменяется ( если доступно, включите любые фрагменты кода, скриншоты или gifs ):

<! - Дайте нам знать, что вы меняете. Поделитесь всем, что может обеспечить максимальный контекст.
Если вы внесли изменения в каталог `content`, таблица будет заполняться в комментарии ниже со ссылками на предварительный просмотр и текущие производственные статьи. - >

### Отметьте следующее:

- [ ] Я рассмотрел свои изменения в постановке (, посмотрел «Автоматически сгенерированный комментарий» и щелкнул ссылки в столбце «Предварительный просмотр», чтобы просмотреть ваши последние изменения ).
- [ ] Для изменений содержимого я заполнил контрольный список [ для самоконтроля ] ( https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).