### PR TITLE
Bump liquidjs from 9.22.1 to 10.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "javascript-stringify": "^2.1.0",
         "js-cookie": "^3.0.1",
         "js-yaml": "^4.1.0",
-        "liquidjs": "9.22.1",
+        "liquidjs": "10.4.0",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "lowdb": "5.0.5",
@@ -14029,14 +14029,15 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "9.22.1",
-      "license": "MIT",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.4.0.tgz",
+      "integrity": "sha512-4fpR8KFJ96bXkzynK9Yo1jwn7sjOkJfKawSbEXINc39DZfy7r5SYtcAM5T/Ccg5n0xoZf6ap5Gap4VwFCJiQ1g==",
       "bin": {
         "liquid": "bin/liquid.js",
         "liquidjs": "bin/liquid.js"
       },
       "engines": {
-        "node": ">=4.8.7"
+        "node": ">=14"
       },
       "funding": {
         "type": "opencollective",
@@ -30333,7 +30334,9 @@
       }
     },
     "liquidjs": {
-      "version": "9.22.1"
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.4.0.tgz",
+      "integrity": "sha512-4fpR8KFJ96bXkzynK9Yo1jwn7sjOkJfKawSbEXINc39DZfy7r5SYtcAM5T/Ccg5n0xoZf6ap5Gap4VwFCJiQ1g=="
     },
     "listr2": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "javascript-stringify": "^2.1.0",
     "js-cookie": "^3.0.1",
     "js-yaml": "^4.1.0",
-    "liquidjs": "9.22.1",
+    "liquidjs": "10.4.0",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "lowdb": "5.0.5",


### PR DESCRIPTION
Насосы [ liquidjs ] ( с 9.22.1 по 10.4.0.
- [ Примечания к выпуску ] ( https://github.com/harttle/liquidjs/releases)
- [ Changelog ] ( https://github.com/harttle/liquidjs/blob/master/CHANGELOG.md)
- [ Команды ] ( https://github.com/harttle/liquidjs/compare/v9.22.1...v10.4.0)

---
обновленные зависимости:
- имя зависимости: liquidjs тип зависимости: прямой: тип обновления производства: версия-обновление: semver-major ...

<! -
Спасибо за участие в этом проекте! Вы должны заполнить информацию ниже, прежде чем мы сможем просмотреть этот запрос. Объясняя, почему вы вносите изменения ( или ссылаетесь на проблему ) и какие изменения вы внесли, мы можем перенастроить ваш запрос на извлечение в лучшую команду для рассмотрения.
- >

### Почему:

Закрывает вопрос

<! - Если есть проблема для вашего изменения, пожалуйста, замените ISSUE выше ссылкой на проблему.
Если существует _not_ существующая проблема, сначала откройте ее, чтобы повысить вероятность принятия этого обновления: https://github.com/github/документы / проблемы / новые / выбор. - >

### Что изменяется ( если доступно, включите любые фрагменты кода, скриншоты или gifs ):

<! - Дайте нам знать, что вы меняете. Поделитесь всем, что может обеспечить максимальный контекст.
Если вы внесли изменения в каталог `content`, таблица будет заполняться в комментарии ниже со ссылками на предварительный просмотр и текущие производственные статьи. -- >

### Отметьте следующее:

- [x] Я рассмотрел свои изменения в постановке (, посмотрел «Автоматически сгенерированный комментарий» и щелкнул ссылки в столбце «Предварительный просмотр», чтобы просмотреть ваши последние изменения ).
- [x] Для изменений содержимого я заполнил контрольный список [ для самоконтроля ] ( https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).