### PR TITLE
Bump node from 16.18.0-alpine to 19.1.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # --------------------------------------------------------------------------------
 # BASE IMAGE
 # --------------------------------------------------------------------------------
-FROM node:16.18.0-alpine@sha256:f16544bc93cf1a36d213c8e2efecf682e9f4df28429a629a37aaf38ecfc25cf4 as base
+FROM node:19.1.0-alpine@sha256:c59fb39150e4a7ae14dfd42d3f9874398c7941784b73049c2d274115f00d36c8 as base
 
 # This directory is owned by the node user
 ARG APP_HOME=/home/node/app

--- a/Dockerfile.openapi_decorator
+++ b/Dockerfile.openapi_decorator
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:19-alpine
 
 RUN apk add --no-cache git python make g++
 


### PR DESCRIPTION
Узел бобовых от 16.18.0-альпийского до 19.1.0-альпийского.

---
обновленные зависимости:
- имя зависимости: тип зависимости узла: прямой: тип обновления производства: версия-обновление: semver-major ...

<! -
Спасибо за участие в этом проекте! Вы должны заполнить информацию ниже, прежде чем мы сможем просмотреть этот запрос. Объясняя, почему вы вносите изменения ( или ссылаетесь на проблему ) и какие изменения вы внесли, мы можем перенастроить ваш запрос на извлечение в лучшую команду для рассмотрения.
- >

### Почему:

Закрывает вопрос

<! - Если есть проблема для вашего изменения, пожалуйста, замените ISSUE выше ссылкой на проблему.
Если существует _not_ существующая проблема, сначала откройте ее, чтобы повысить вероятность принятия этого обновления: https://github.com/github/docs/issues/new/choose. - >

### Что изменяется ( если доступно, включите любые фрагменты кода, скриншоты или gifs ):

<! - Дайте нам знать, что вы меняете. Поделитесь всем, что может обеспечить максимальный контекст.
Если вы внесли изменения в каталог `content`, таблица будет заполняться в комментарии ниже со ссылками на предварительный просмотр и текущие производственные статьи. -- >

### Отметьте следующее:

- [ ] Я рассмотрел свои изменения в постановке (, посмотрел «Автоматически сгенерированный комментарий» и щелкнул ссылки в столбце «Предварительный просмотр», чтобы просмотреть ваши последние изменения ).
- [ ] Для изменений содержимого я заполнил контрольный список [ для самоконтроля ] ( https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).