### PR TITLE
Bump mkdirp from 1.0.4 to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
         "lint-staged": "^13.0.1",
         "make-promises-safe": "^5.1.0",
         "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
+        "mkdirp": "^2.1.1",
         "mockdate": "^3.0.5",
         "nock": "^13.2.7",
         "nodemon": "2.0.20",
@@ -15386,14 +15386,18 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.1.tgz",
+      "integrity": "sha512-tXNRfEiv5Z5R1jrXKfSNwhzDjMPdSZqYC1co5ZC7yjNwClJ0Hqt5NGRAayuK6urzM5MWX2IGFLAT4Gs1saeYQw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -31342,7 +31346,9 @@
       }
     },
     "mkdirp": {
-      "version": "1.0.4",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.1.tgz",
+      "integrity": "sha512-tXNRfEiv5Z5R1jrXKfSNwhzDjMPdSZqYC1co5ZC7yjNwClJ0Hqt5NGRAayuK6urzM5MWX2IGFLAT4Gs1saeYQw==",
       "dev": true
     },
     "mkdirp-classic": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "lint-staged": "^13.0.1",
     "make-promises-safe": "^5.1.0",
     "minimatch": "^5.1.0",
-    "mkdirp": "^1.0.4",
+    "mkdirp": "^2.1.1",
     "mockdate": "^3.0.5",
     "nock": "^13.2.7",
     "nodemon": "2.0.20",


### PR DESCRIPTION
Удары [ mkdirp ] ( https://github.com/isaacs/node-mkdirp) с 1.0.4 по 2.1.1.
- [ Примечания к выпуску ] ( https://github.com/isaacs/node-mkdirp/releases)
- [ Changelog ] ( https://github.com/isaacs/node-mkdirp/blob/main/CHANGELOG.md)
- [ Команды ] ( https://github.com/isaacs/node-mkdirp/compare/v1.0.4...v2.1.1)

---
обновленные зависимости:
- имя зависимости: mkdirp тип зависимости: direct: разработка тип обновления: версия-обновление: semver-major ...

<! -
Спасибо за участие в этом проекте! Вы должны заполнить информацию ниже, прежде чем мы сможем просмотреть этот запрос. Объясняя, почему вы вносите изменения ( или ссылаетесь на проблему ) и какие изменения вы внесли, мы можем перенастроить ваш запрос на извлечение в лучшую команду для рассмотрения.
- >

### Почему:

Закрывает вопрос

<! - Если есть проблема для вашего изменения, пожалуйста, замените ISSUE выше ссылкой на проблему.
Если существует _not_ существующая проблема, сначала откройте ее, чтобы повысить вероятность принятия этого обновления: https://github.com/github/документы / проблемы / новые / выбор. - >

### Что изменяется ( если доступно, включите любые фрагменты кода, скриншоты или gifs ):

<! - Дайте нам знать, что вы меняете. Поделитесь всем, что может обеспечить максимальный контекст.
Если вы внесли изменения в каталог `content`, таблица будет заполняться в комментарии ниже со ссылками на предварительный просмотр и текущие производственные статьи. -- >

### Отметьте следующее:

- [ ] Я рассмотрел свои изменения в постановке (, посмотрел «Автоматически сгенерированный комментарий» и щелкнул ссылки в столбце «Предварительный просмотр», чтобы просмотреть ваши последние изменения ).
- [ ] Для изменений содержимого я заполнил контрольный список [ для самоконтроля ] ( https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).