### PR TITLE
Bump node from 18.14-alpine to 19.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------------
 # To update the sha, run `docker pull node:$VERSION-alpine`
 # look for something like: `Digest: sha256:0123456789abcdef`
-FROM node:18.14-alpine@sha256:045b1a1c90bdfd8fcaad0769922aa16c401e31867d8bf5833365b0874884bbae as base
+FROM node:19.7-alpine@sha256:667dc6ed8fc6623ccd21cb5fa355c90f848daaf5d6df96bc940869bfdf91c19a as base
 
 # This directory is owned by the node user
 ARG APP_HOME=/home/node/app

--- a/Dockerfile.openapi_decorator
+++ b/Dockerfile.openapi_decorator
@@ -1,4 +1,4 @@
-FROM node:18.14-alpine
+FROM node:19.7-alpine
 
 RUN apk add --no-cache git python make g++
 


### PR DESCRIPTION
Узел Bumps от 18,14-альпийского до 19,7-альпийского.

---
обновленные зависимости:
- имя зависимости: тип зависимости узла: прямой: производство ...

<! -
Спасибо за участие в этом проекте! Вы должны заполнить информацию ниже, прежде чем мы сможем просмотреть этот запрос. Объясняя, почему вы вносите изменения ( или ссылаетесь на проблему ) и какие изменения вы внесли, мы можем перенастроить ваш запрос на извлечение в лучшую команду для рассмотрения.
- >

### Почему:

Закрывает вопрос

<! - Если есть проблема для вашего изменения, пожалуйста, замените ISSUE выше ссылкой на проблему.
Если существует _not_ существующая проблема, сначала откройте ее, чтобы повысить вероятность принятия этого обновления: https://github.com/github/docs/issues/new/choose. - >

### Что изменяется ( если доступно, включите любые фрагменты кода, скриншоты или gifs ):

<! - Дайте нам знать, что вы меняете. Поделитесь всем, что может обеспечить максимальный контекст.
Если вы внесли изменения в каталог `content`, таблица будет заполняться в комментарии ниже со ссылками на предварительный просмотр и текущие производственные статьи. - >

### Отметьте следующее:

- [x] Я рассмотрел свои изменения в постановке (, посмотрел «Автоматически сгенерированный комментарий» и щелкнул ссылки в столбце «Предварительный просмотр», чтобы просмотреть ваши последние изменения ).
- [x] Для изменений содержимого я заполнил контрольный список [ для самоконтроля ] ( https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).